### PR TITLE
削除関数ハンドリングを追加

### DIFF
--- a/src/components/Note/NoteList.tsx
+++ b/src/components/Note/NoteList.tsx
@@ -1,4 +1,4 @@
-import { deleteNote } from '@/utils/note/deleteNote';
+import { useNotes } from '@/hooks/note/useNotes';
 import { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPen, faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -15,6 +15,9 @@ const NoteList: React.FC<NoteListProps> = ({
   const [selectEditTitleNoteId, setSelectEditTitleNoteId] = useState<
     number | null
   >(null);
+
+  console.log(notes);
+  const { handleDeleteAction } = useNotes();
   return (
     <ul className='space-y-2'>
       {notes.map((note) => (
@@ -54,7 +57,7 @@ const NoteList: React.FC<NoteListProps> = ({
             </button>
             <button
               className='ml-2 text-blue-500'
-              onClick={() => deleteNote(note.id)}
+              onClick={() => handleDeleteAction(note.id)}
             >
               <FontAwesomeIcon icon={faTrash} />
             </button>

--- a/src/hooks/note/useNotes.ts
+++ b/src/hooks/note/useNotes.ts
@@ -35,6 +35,11 @@ export const useNotes = () => {
     await updateNoteTitle(currentNoteId, title);
   };
 
+  const handleDeleteAction = async (id: number) => {
+    await deleteNote(id);
+    fetchNotesCallback();
+  };
+
   useEffect(() => {
     fetchNotesCallback();
 
@@ -55,5 +60,6 @@ export const useNotes = () => {
     handleNewNote,
     handleContentChange,
     handleChangeTitle,
+    handleDeleteAction,
   };
 };


### PR DESCRIPTION
親コンポーネントから関数を渡していなかったから親コンポーネントより先に削除処理よりも先に親コンポーネントの再レンダリングが行われてしまって削除したはずのタイトルを表示させてしまっていたため